### PR TITLE
SSID for ACF and APM - fixes #18

### DIFF
--- a/config/__config__schema.json
+++ b/config/__config__schema.json
@@ -202,9 +202,6 @@
         "acf_ssid":{
           "type": "string"
         },
-        "apm_ssid":{
-          "type": "string"
-        },
         "ignore_cert": {
           "type": "boolean",
           "default": false
@@ -243,7 +240,7 @@
             }
           },
           "then": {
-            "required": ["sys_id","acf_ssid","apm_ssid"]
+            "required": ["sys_id","acf_ssid"]
           }
         }
       ],

--- a/config/__config__schema.json
+++ b/config/__config__schema.json
@@ -194,11 +194,6 @@
           "minLength": 3,
           "maxLength": 3
         },
-        "sys_id": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 3
-        },
         "acf_ssid":{
           "type": "string"
         },
@@ -240,7 +235,7 @@
             }
           },
           "then": {
-            "required": ["sys_id","acf_ssid"]
+            "required": ["acf_ssid"]
           }
         }
       ],

--- a/config/__config__schema.json
+++ b/config/__config__schema.json
@@ -199,6 +199,12 @@
           "minLength": 3,
           "maxLength": 3
         },
+        "acf_ssid":{
+          "type": "string"
+        },
+        "apm_ssid":{
+          "type": "string"
+        },
         "ignore_cert": {
           "type": "boolean",
           "default": false
@@ -237,7 +243,7 @@
             }
           },
           "then": {
-            "required": ["sys_id"]
+            "required": ["sys_id","acf_ssid","apm_ssid"]
           }
         }
       ],

--- a/config/sample-config.yaml
+++ b/config/sample-config.yaml
@@ -62,6 +62,7 @@ systems:
     sys_id: "ERP"
     client: "910"
     type: "ERP"
+    acf_ssid: "ERP_910"
     host: "https://host.tld:44320"
     ignore_cert: false
     credentials:

--- a/config/sample-config.yaml
+++ b/config/sample-config.yaml
@@ -59,7 +59,6 @@ systems:
 
   # ERP system
   - name: "ERP_910"
-    sys_id: "ERP"
     client: "910"
     type: "ERP"
     acf_ssid: "ERP_910"

--- a/notebooks/modules/util/api.py
+++ b/notebooks/modules/util/api.py
@@ -271,9 +271,7 @@ class ACFClient(APIClient):
         self.erp_config = get_system_by_type(self.config, "ERP")
         if self.erp_config is None:
             raise ValueError("ERP system not found in configuration")
-        self.erp_ssid = (
-            f"{str(self.erp_config['sys_id']).upper()}_{self.erp_config['client']}"
-        )
+        self.erp_ssid = self.erp_config.get("acf_ssid")
 
 
 class APMClient(APIClient):
@@ -308,9 +306,7 @@ class APMClient(APIClient):
         self.erp_config = get_system_by_type(self.config, "ERP")
         if self.erp_config is None:
             raise ValueError("ERP system not found in configuration")
-        self.erp_ssid = (
-            f"{str(self.erp_config['sys_id']).upper()}_{self.erp_config['client']}"
-        )
+        self.erp_ssid = self.erp_config.get("apm_ssid")
 
 
 class ERPClient:

--- a/notebooks/modules/util/api.py
+++ b/notebooks/modules/util/api.py
@@ -330,11 +330,6 @@ class APMClient(APIClient):
 
         self.base_url = f"{self.base_url}/{service}/v1"
 
-        # self.erp_config = get_system_by_type(self.config, "ERP")
-        # if self.erp_config is None:
-        #     raise ValueError("ERP system not found in configuration")
-        # self.erp_ssid = self.get_external_ssid(config_id)
-
 
 class ERPClient:
 


### PR DESCRIPTION
Fixes #18
 
### Resolution:
1. Added Parameter: `acf_ssid`
2. Removed parameter: `sys_id`
3. `ACFClient` assigns the `erp_ssid` attribute with `acf_ssid`
4. `APMClient` assigns the `erp_ssid` attribute with the SSID it gets from the first technical object it can fetch from APM.
    - In case if there are no Technical Objects in APM / no SSID assigned, it would raise an error message
    - Assumption: There is only one SSID assigned to all technical objects in APM

This ensures that there is a control and if there is a difference between the SSIDs during extraction (from ACF) or while posting (into APM) individual values are considered.